### PR TITLE
Make execute auth call a suspend function

### DIFF
--- a/app/auth/src/main/java/com/duchastel/simon/photocategorizer/auth/AuthProvider.kt
+++ b/app/auth/src/main/java/com/duchastel/simon/photocategorizer/auth/AuthProvider.kt
@@ -24,12 +24,11 @@ interface AuthProvider {
      * Execute an API request with a valid AuthToken. May refresh the token under the hood,
      * so expect this call to potentially be long-running.
      *
-     * Must be called after successfully logging in, otherwise
+     * Must be called after successfully logging in.
      */
-    fun executeWithAuthToken(
-        execute: (authToken: AuthToken) -> Unit,
-        onError: (error: Exception) -> Unit,
-    )
+    suspend fun <T> executeWithAuthToken(
+        execute: suspend (authToken: AuthToken) -> T,
+    ): T
 }
 
 data class AuthToken(

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/MainActivity.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/MainActivity.kt
@@ -35,6 +35,7 @@ import com.duchastel.simon.photocategorizer.auth.AuthProvider
 import com.duchastel.simon.photocategorizer.filemanager.FileManager
 import com.duchastel.simon.photocategorizer.ui.theme.PhotoCategorizerTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.io.IOException
@@ -77,21 +78,16 @@ class MainActivity : ComponentActivity() {
                     delay(1000)
                     timer -= 1
                 }
-                authProvider.executeWithAuthToken(
-                    execute = { token ->
-                        scope.launch {
-                            try {
-                                fileNames = fileManager.listPhotos(token.accessToken).map { it.name }
-                                println("TODO - $fileNames")
-                            } catch (ex: IOException) {
-                                println("NETWORK ERROR: $ex")
-                            }
+                scope.launch {
+                    try {
+                        authProvider.executeWithAuthToken { token ->
+                            fileNames = fileManager.listPhotos(token.accessToken).map { it.name }
+                            println("TODO - $fileNames")
                         }
-                    },
-                    onError = { error ->
-                        println("ERROR: $error")
+                    } catch (ex: Exception) {
+                        println("NETWORK ERROR: $ex")
                     }
-                )
+                }
             }
 
             PhotoCategorizerTheme {


### PR DESCRIPTION
The OpenId AppAuth library uses callbacks, but the rest of the app uses coroutines. The `execute` call is now a suspend function to easily integrate with the suspend network calls.