### PR TITLE
Implement infinite scroll

### DIFF
--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/login/LoginScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/login/LoginScreen.kt
@@ -26,10 +26,6 @@ import com.duchastel.simon.photocategorizer.MainActivity
 
 @Composable
 fun LoginScreen(viewModel: LoginViewModel = hiltViewModel()) {
-    LaunchedEffect(Unit) {
-        println("TODO - Login")
-    }
-
     val state by viewModel.state.collectAsState()
 
     val context = LocalContext.current

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -1,18 +1,34 @@
 package com.duchastel.simon.photocategorizer.screens.photoswiper
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntOffset
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
+import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.DisplayPhoto
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 @Composable
 fun PhotoSwiperScreen(
@@ -22,21 +38,101 @@ fun PhotoSwiperScreen(
     val state by viewModel.state.collectAsState()
 
     PhotoSwiperContent(
-        photoUris = state.photos.map { it.displayUrl }.filterNotNull(),
+        photos = state.photos.filter { it.displayUrl != null },
         onLogoutClicked = logout,
     )
+//    SwipeScreen(photos = state.photos.filter { it.displayUrl != null })
+}
+
+@Composable
+fun SwipeCard(
+    modifier: Modifier = Modifier,
+    cardContent: @Composable () -> Unit,
+    onSwipeLeft: () -> Unit,
+    onSwipeRight: () -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val offsetX = remember { Animatable(0f) }
+    val swipeThreshold = 300f
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures { _, dragAmount ->
+                    coroutineScope.launch {
+                        offsetX.snapTo(targetValue = offsetX.value + dragAmount)
+                    }
+                }
+            }
+            .offset { IntOffset(offsetX.value.roundToInt(), 0) }
+            .graphicsLayer {
+                rotationZ = offsetX.value / 15f
+            }
+            .onGloballyPositioned {
+                // Handle swipe actions
+                if (offsetX.value > swipeThreshold) {
+                    onSwipeRight()
+                    coroutineScope.launch {
+                        offsetX.snapTo(0f)
+                    }
+                } else if (offsetX.value < -swipeThreshold) {
+                    onSwipeLeft()
+                    coroutineScope.launch {
+                        offsetX.snapTo(0f)
+                    }
+                }
+            }
+    ) {
+        cardContent()
+    }
+}
+
+@Composable
+fun SwipeScreen(photos: List<DisplayPhoto>) {
+    if (photos.isEmpty()) return
+    var swipeMessage by remember { mutableStateOf("Swipe a card!") }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(swipeMessage)
+        SwipeCard(
+            cardContent = {
+                AsyncImage(
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                    model = photos.first().displayUrl,
+                    contentDescription = "Photo",
+                )
+            },
+            onSwipeLeft = {
+                swipeMessage = "Swiped Left!"
+            },
+            onSwipeRight = {
+                swipeMessage = "Swiped Right!"
+            }
+        )
+    }
 }
 
 @Composable
 private fun PhotoSwiperContent(
-    photoUris: List<String>,
+    photos: List<DisplayPhoto>,
     onLogoutClicked: () -> Unit
 ) {
+    if (photos.isEmpty()) return
     Column(modifier = Modifier.fillMaxSize()) {
+        val pagerState = rememberPagerState(pageCount = { photos.size })
+        val userScrollEnabled by remember {
+            derivedStateOf {
+                pagerState.currentPageOffsetFraction <= 0
+            }
+        }
 
-        val pagerState = rememberPagerState(pageCount = { photoUris.size })
-        VerticalPager(state = pagerState) { page ->
-            val photoUri = photoUris[page]
+        VerticalPager(
+            state = pagerState,
+            userScrollEnabled = userScrollEnabled,
+        ) { page ->
+            val photoUri = photos[page].displayUrl
             AsyncImage(
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -116,6 +116,7 @@ private fun PhotoSwiperContent(
 
         VerticalPager(
             state = pagerState,
+            beyondViewportPageCount = 1, // pre-load 1 image after the current one
             modifier = Modifier.pointerInput(Unit) {
                 awaitEachGesture {
                     val currentPageOffsetFraction = pagerState.currentPageOffsetFraction

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
@@ -36,6 +36,13 @@ class PhotoSwiperViewModel @Inject constructor(
         }
     }
 
+    fun processPhoto(photo: DisplayPhoto) {
+        _state.update { oldState ->
+            println("TODO PROCESSING ${_state.value.photos.indexOf(photo)}")
+            oldState.copy(photos = oldState.photos.filter { it != photo })
+        }
+    }
+
     private suspend fun syncDisplayUrls(
         photos: List<DisplayPhoto>,
     ) = coroutineScope {


### PR DESCRIPTION
Add continuous loading of temporary links in the background (buffer of 10) so that we can infinite scroll, and add pre-rendering of 2 images past the current one so that we always have images loaded in memory.


![output](https://github.com/user-attachments/assets/a1157f5f-20af-45ab-805e-d2fa5c779c69)
