### PR TITLE
Image loading UI and preloading

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,7 @@ android {
         jvmTarget = "11"
     }
     buildFeatures {
+        buildConfig = true
         compose = true
     }
 }
@@ -60,6 +61,7 @@ dependencies {
     implementation(libs.androidx.material3)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
     implementation(libs.kotlinx.serialization.json)
 
     ksp(libs.hilt.compiler)

--- a/app/modules/dropbox/src/main/java/com/duchastel/simon/photocategorizer/dropbox/files/DropboxPhotoRepository.kt
+++ b/app/modules/dropbox/src/main/java/com/duchastel/simon/photocategorizer/dropbox/files/DropboxPhotoRepository.kt
@@ -7,6 +7,7 @@ import com.duchastel.simon.photocategorizer.dropbox.network.ListFolderRequest
 import com.duchastel.simon.photocategorizer.dropbox.network.TemporaryLinkRequest
 import com.duchastel.simon.photocategorizer.filemanager.PhotoRepository
 import com.duchastel.simon.photocategorizer.filemanager.Photo
+import com.duchastel.simon.photocategorizer.filemanager.SUPPORTED_FILE_EXTENSIONS
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,7 +23,7 @@ internal class DropboxPhotoRepository @Inject constructor(
             val response = if (cursor == null) {
                 networkApi.listFolder(
                     ListFolderRequest(
-                        path = "id:QjViWc9B0fAAAAAAAAAjtg",
+                        path = "/camera uploads",
                     )
                 )
             } else {
@@ -32,6 +33,10 @@ internal class DropboxPhotoRepository @Inject constructor(
             photos += response.entries
                 .filter { it.tag == FileTag.FILE && it.pathLower != null && it.id != null }
                 .map { Photo(name = it.name, id = it.id!!, path = it.pathLower!!) }
+                .filter { photo ->
+                    // filter for photos that match one of the supported extensions
+                    SUPPORTED_FILE_EXTENSIONS.any { photo.path.endsWith(it) }
+                }
 
             cursor = response.cursor
         } while (response.hasMore)

--- a/app/modules/dropbox/src/main/java/com/duchastel/simon/photocategorizer/dropbox/network/Models.kt
+++ b/app/modules/dropbox/src/main/java/com/duchastel/simon/photocategorizer/dropbox/network/Models.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ListFolderRequest(
     @Json(name = "path") val path: String,
-    @Json(name = "limit") val limit: Int? = null
+    @Json(name = "limit") val limit: Int? = 2000
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/modules/filemanager/src/main/java/com/duchastel/simon/photocategorizer/filemanager/PhotoRepository.kt
+++ b/app/modules/filemanager/src/main/java/com/duchastel/simon/photocategorizer/filemanager/PhotoRepository.kt
@@ -5,6 +5,8 @@ interface PhotoRepository {
     suspend fun getUnauthenticatedLinkForPhoto(path: String): String
 }
 
+val SUPPORTED_FILE_EXTENSIONS: List<String> = listOf(".png", ".jpg")
+
 data class Photo(
     val name: String,
     val id: String,

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/App.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/App.kt
@@ -1,7 +1,20 @@
 package com.duchastel.simon.photocategorizer
 
 import android.app.Application
+import android.content.Context
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.request.crossfade
+import coil3.util.DebugLogger
+import com.duchastel.simon.photocategorizer.utils.applyIf
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class App: Application()
+class App: Application(), SingletonImageLoader.Factory {
+    override fun newImageLoader(context: Context): ImageLoader {
+        return ImageLoader.Builder(context)
+            .crossfade(true)
+            .applyIf(BuildConfig.DEBUG) { logger(DebugLogger()) }
+            .build()
+    }
+}

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -1,18 +1,13 @@
 package com.duchastel.simon.photocategorizer.screens.photoswiper
 
-import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.SubcomposeAsyncImage
-import coil.imageLoader
-import coil.request.ImageRequest
-import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.Companion.PHOTO_BUFFER_SIZE
 import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.DisplayPhoto
 import com.duchastel.simon.photocategorizer.ui.components.HorizontalSwiper
 import com.duchastel.simon.photocategorizer.ui.components.OneWayVerticalSwiper
@@ -35,27 +30,28 @@ private fun PhotoSwiperContent(
     photos: List<DisplayPhoto>,
     processPhoto: (DisplayPhoto) -> Unit,
 ) {
-    SkeletonLoader()
-    return
-    if (photos.isEmpty()) return
-    val context = LocalContext.current
-    LaunchedEffect(photos) {
-        // preload the first few photos in the buffer initially
-        for (index in 1..<PHOTO_BUFFER_SIZE) {
-            if (index <= photos.lastIndex) {
-                println("TODO - preloading $index")
-                context.preloadPhoto(photos[index])
-            }
-        }
+    if (photos.isEmpty()) {
+        SkeletonLoader()
+        return
     }
-    LaunchedEffect(photos, currentIndex) {
-        // every time the index changes, preload the next photo in the index
-        val index = currentIndex + PHOTO_BUFFER_SIZE
-        if (index <= photos.lastIndex) {
-            println("TODO - preloading $index + PHOTO_BUFFER_SIZE")
-            context.preloadPhoto(photos[index])
-        }
-    }
+//    val context = LocalContext.current
+//    LaunchedEffect(photos) {
+//        // preload the first few photos in the buffer initially
+//        for (index in 1..<PHOTO_BUFFER_SIZE) {
+//            if (index <= photos.lastIndex) {
+//                println("TODO - preloading $index")
+//                context.preloadPhoto(photos[index])
+//            }
+//        }
+//    }
+//    LaunchedEffect(photos, currentIndex) {
+//        // every time the index changes, preload the next photo in the index
+//        val index = currentIndex + PHOTO_BUFFER_SIZE
+//        if (index <= photos.lastIndex) {
+//            println("TODO - preloading $index + PHOTO_BUFFER_SIZE")
+//            context.preloadPhoto(photos[index])
+//        }
+//    }
 
 
     OneWayVerticalSwiper(

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.DisplayPhoto

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -31,6 +31,7 @@ private fun PhotoSwiperContent(
     processPhoto: (DisplayPhoto) -> Unit,
 ) {
     if (photos.isEmpty()) return
+    val context = LocalContext.current
     OneWayVerticalSwiper(
         modifier = Modifier.fillMaxSize(),
         items = photos,

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -1,15 +1,23 @@
 package com.duchastel.simon.photocategorizer.screens.photoswiper
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.SubcomposeAsyncImage
+import coil3.compose.SubcomposeAsyncImage
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.size.Size
+import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.Companion.PHOTO_BUFFER_SIZE
 import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.DisplayPhoto
 import com.duchastel.simon.photocategorizer.ui.components.HorizontalSwiper
 import com.duchastel.simon.photocategorizer.ui.components.OneWayVerticalSwiper
@@ -20,28 +28,28 @@ fun PhotoSwiperScreen(
     viewModel: PhotoSwiperViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
+    val photos = state.photos
 
-//    val context = LocalContext.current
-//    LaunchedEffect(photos) {
-//        // preload the first few photos in the buffer initially
-//        for (index in 1..<PHOTO_BUFFER_SIZE) {
-//            if (index <= photos.lastIndex) {
-//                println("TODO - preloading $index")
-//                context.preloadPhoto(photos[index])
-//            }
-//        }
-//    }
-//    LaunchedEffect(photos, currentIndex) {
-//        // every time the index changes, preload the next photo in the index
-//        val index = currentIndex + PHOTO_BUFFER_SIZE
-//        if (index <= photos.lastIndex) {
-//            println("TODO - preloading $index + PHOTO_BUFFER_SIZE")
-//            context.preloadPhoto(photos[index])
-//        }
-//    }
+    val context = LocalContext.current
+    val imageLoader = context.imageLoader
+    LaunchedEffect(photos, context, imageLoader) {
+        // preload the first few photos in the buffer initially
+        photos
+            .filter { it.displayUrl != null }
+            .filter { it.imageRequest == null }
+            .take(PHOTO_BUFFER_SIZE)
+            .forEach { photo ->
+                val request = ImageRequest.Builder(context)
+                    .data(photo.displayUrl)
+                    .size(Size.ORIGINAL)
+                    .build()
+                imageLoader.enqueue(request)
+                viewModel.attachImageRequest(photo, request)
+            }
+    }
 
     PhotoSwiperContent(
-        photos = state.photos.filter { it.displayUrl != null },
+        photos = photos.filter { it.imageRequest != null },
         processPhoto = viewModel::processPhoto,
     )
 }
@@ -49,7 +57,7 @@ fun PhotoSwiperScreen(
 @Composable
 private fun PhotoSwiperContent(
     photos: List<DisplayPhoto>,
-    processPhoto: (DisplayPhoto) -> Unit,
+    processPhoto: (Int) -> Unit,
 ) {
     if (photos.isEmpty()) {
         SkeletonLoader(modifier = Modifier.padding(16.dp))
@@ -58,24 +66,39 @@ private fun PhotoSwiperContent(
 
     OneWayVerticalSwiper(
         modifier = Modifier.fillMaxSize(),
-        items = photos,
-        onSwipe = { photo ->
-            processPhoto(photo)
+        onSwipe = { index ->
+            processPhoto(index)
         },
-    ) { photo ->
+    ) { index ->
+        val photo = photos[index]
         HorizontalSwiper(
-            onSwipeLeft = { processPhoto(photo) },
-            onSwipeRight = { processPhoto(photo) },
+            onSwipeLeft = { processPhoto(index) },
+            onSwipeRight = { processPhoto(index) },
         ) {
             SubcomposeAsyncImage(
                 modifier = Modifier.fillMaxSize(),
-                model = photo.displayUrl,
+                model = photo.imageRequest,
                 contentScale = ContentScale.Crop,
                 contentDescription = photo.path,
                 loading = {
                     SkeletonLoader(modifier = Modifier.padding(16.dp))
                 },
             )
+        }
+
+        // pre-render next image to avoid jitter
+        if (index < photos.lastIndex) {
+            Box(modifier = Modifier.alpha(0f)) {
+                SubcomposeAsyncImage(
+                    modifier = Modifier.fillMaxSize(),
+                    model = photos[index + 1].imageRequest,
+                    contentScale = ContentScale.Crop,
+                    contentDescription = photos[index + 1].path,
+                    loading = {
+                        SkeletonLoader(modifier = Modifier.padding(16.dp))
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -1,11 +1,13 @@
 package com.duchastel.simon.photocategorizer.screens.photoswiper
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.SubcomposeAsyncImage
 import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.DisplayPhoto
@@ -19,21 +21,6 @@ fun PhotoSwiperScreen(
 ) {
     val state by viewModel.state.collectAsState()
 
-    PhotoSwiperContent(
-        photos = state.photos.filter { it.displayUrl != null },
-        processPhoto = viewModel::processPhoto,
-    )
-}
-
-@Composable
-private fun PhotoSwiperContent(
-    photos: List<DisplayPhoto>,
-    processPhoto: (DisplayPhoto) -> Unit,
-) {
-    if (photos.isEmpty()) {
-        SkeletonLoader()
-        return
-    }
 //    val context = LocalContext.current
 //    LaunchedEffect(photos) {
 //        // preload the first few photos in the buffer initially
@@ -53,6 +40,21 @@ private fun PhotoSwiperContent(
 //        }
 //    }
 
+    PhotoSwiperContent(
+        photos = state.photos.filter { it.displayUrl != null },
+        processPhoto = viewModel::processPhoto,
+    )
+}
+
+@Composable
+private fun PhotoSwiperContent(
+    photos: List<DisplayPhoto>,
+    processPhoto: (DisplayPhoto) -> Unit,
+) {
+    if (photos.isEmpty()) {
+        SkeletonLoader(modifier = Modifier.padding(16.dp))
+        return
+    }
 
     OneWayVerticalSwiper(
         modifier = Modifier.fillMaxSize(),
@@ -71,7 +73,7 @@ private fun PhotoSwiperContent(
                 contentScale = ContentScale.Crop,
                 contentDescription = photo.path,
                 loading = {
-                    SkeletonLoader()
+                    SkeletonLoader(modifier = Modifier.padding(16.dp))
                 },
             )
         }

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -1,5 +1,6 @@
 package com.duchastel.simon.photocategorizer.screens.photoswiper
 
+import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -8,10 +9,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
+import coil.imageLoader
+import coil.request.ImageRequest
+import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.Companion.PHOTO_BUFFER_SIZE
 import com.duchastel.simon.photocategorizer.screens.photoswiper.PhotoSwiperViewModel.DisplayPhoto
 import com.duchastel.simon.photocategorizer.ui.components.HorizontalSwiper
 import com.duchastel.simon.photocategorizer.ui.components.OneWayVerticalSwiper
+import com.duchastel.simon.photocategorizer.ui.components.SkeletonLoader
 
 @Composable
 fun PhotoSwiperScreen(
@@ -30,8 +35,29 @@ private fun PhotoSwiperContent(
     photos: List<DisplayPhoto>,
     processPhoto: (DisplayPhoto) -> Unit,
 ) {
+    SkeletonLoader()
+    return
     if (photos.isEmpty()) return
     val context = LocalContext.current
+    LaunchedEffect(photos) {
+        // preload the first few photos in the buffer initially
+        for (index in 1..<PHOTO_BUFFER_SIZE) {
+            if (index <= photos.lastIndex) {
+                println("TODO - preloading $index")
+                context.preloadPhoto(photos[index])
+            }
+        }
+    }
+    LaunchedEffect(photos, currentIndex) {
+        // every time the index changes, preload the next photo in the index
+        val index = currentIndex + PHOTO_BUFFER_SIZE
+        if (index <= photos.lastIndex) {
+            println("TODO - preloading $index + PHOTO_BUFFER_SIZE")
+            context.preloadPhoto(photos[index])
+        }
+    }
+
+
     OneWayVerticalSwiper(
         modifier = Modifier.fillMaxSize(),
         items = photos,
@@ -43,11 +69,14 @@ private fun PhotoSwiperContent(
             onSwipeLeft = { processPhoto(photo) },
             onSwipeRight = { processPhoto(photo) },
         ) {
-            AsyncImage(
+            SubcomposeAsyncImage(
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop,
                 model = photo.displayUrl,
+                contentScale = ContentScale.Crop,
                 contentDescription = photo.path,
+                loading = {
+                    SkeletonLoader()
+                },
             )
         }
     }

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
@@ -26,19 +26,19 @@ class PhotoSwiperViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-//            val photos = photoRepository.getPhotos()
-//                .map { DisplayPhoto(path = it.path, displayUrl = null) }
+            val photos = photoRepository.getPhotos()
+                .map { DisplayPhoto(path = it.path, displayUrl = null) }
             // TODO - remove when done testing
-            val photos = listOf(
-                DisplayPhoto(path = "path1", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
-                DisplayPhoto(path = "path2", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
-                DisplayPhoto(path = "path3", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
-                DisplayPhoto(path = "path4", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
-                DisplayPhoto(path = "path5", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
-                DisplayPhoto(path = "path6", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
-                DisplayPhoto(path = "path7", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
-                DisplayPhoto(path = "path8", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
-            )
+//            val photos = listOf(
+//                DisplayPhoto(path = "path1", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
+//                DisplayPhoto(path = "path2", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
+//                DisplayPhoto(path = "path3", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
+//                DisplayPhoto(path = "path4", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
+//                DisplayPhoto(path = "path5", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
+//                DisplayPhoto(path = "path6", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
+//                DisplayPhoto(path = "path7", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
+//                DisplayPhoto(path = "path8", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
+//            )
             _state.update { it.copy(photos = photos) }
         }
 

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
@@ -26,20 +26,9 @@ class PhotoSwiperViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-//            val photos = photoRepository.getPhotos()
-//                .map { DisplayPhoto(path = it.path, displayUrl = null) }
-            // TODO - remove when done testing
-//            val photos = listOf(
-//                DisplayPhoto(path = "path1", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
-//                DisplayPhoto(path = "path2", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
-//                DisplayPhoto(path = "path3", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
-//                DisplayPhoto(path = "path4", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
-//                DisplayPhoto(path = "path5", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
-//                DisplayPhoto(path = "path6", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
-//                DisplayPhoto(path = "path7", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
-//                DisplayPhoto(path = "path8", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
-//            )
-//            _state.update { it.copy(photos = photos) }
+            val photos = photoRepository.getPhotos()
+                .map { DisplayPhoto(path = it.path, displayUrl = null) }
+            _state.update { it.copy(photos = photos) }
         }
 
         viewModelScope.launch {

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
@@ -57,7 +57,7 @@ class PhotoSwiperViewModel @Inject constructor(
 
     fun processPhoto(photo: DisplayPhoto) {
         _state.update { oldState ->
-            oldState.copy(photoIndex = oldState.photos.indexOf(photo))
+            oldState.copy(photoIndex = oldState.photos.indexOf(photo) + 1)
         }
     }
 
@@ -66,9 +66,9 @@ class PhotoSwiperViewModel @Inject constructor(
         photoIndex: Int,
     ) = coroutineScope {
         photos
-            .drop(photoIndex)
-            .take(PHOTO_BUFFER_SIZE)
-            .filter { it.displayUrl == null }
+            .drop(photoIndex) // drop the current photo
+            .take(PHOTO_BUFFER_SIZE) // take the next photos for the buffer
+            .filter { it.displayUrl == null } // ignore already-loaded photos
             .map { photo ->
                 async {
                     val url = photoRepository.getUnauthenticatedLinkForPhoto(photo.path)

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
@@ -26,8 +26,10 @@ class PhotoSwiperViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val photos = photoRepository.getPhotos()
-                .map { DisplayPhoto(path = it.path, displayUrl = null) }
+//            val photos = photoRepository.getPhotos()
+//                .map { DisplayPhoto(path = it.path, displayUrl = null) }
+            // TODO - remove when done testing
+            val photos = listOf(DisplayPhoto(path = "path", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"))
             _state.update { it.copy(photos = photos) }
         }
 

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
@@ -26,8 +26,8 @@ class PhotoSwiperViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val photos = photoRepository.getPhotos()
-                .map { DisplayPhoto(path = it.path, displayUrl = null) }
+//            val photos = photoRepository.getPhotos()
+//                .map { DisplayPhoto(path = it.path, displayUrl = null) }
             // TODO - remove when done testing
 //            val photos = listOf(
 //                DisplayPhoto(path = "path1", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
@@ -39,7 +39,7 @@ class PhotoSwiperViewModel @Inject constructor(
 //                DisplayPhoto(path = "path7", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
 //                DisplayPhoto(path = "path8", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
 //            )
-            _state.update { it.copy(photos = photos) }
+//            _state.update { it.copy(photos = photos) }
         }
 
         viewModelScope.launch {

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperViewModel.kt
@@ -29,7 +29,16 @@ class PhotoSwiperViewModel @Inject constructor(
 //            val photos = photoRepository.getPhotos()
 //                .map { DisplayPhoto(path = it.path, displayUrl = null) }
             // TODO - remove when done testing
-            val photos = listOf(DisplayPhoto(path = "path", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"))
+            val photos = listOf(
+                DisplayPhoto(path = "path1", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
+                DisplayPhoto(path = "path2", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
+                DisplayPhoto(path = "path3", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
+                DisplayPhoto(path = "path4", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
+                DisplayPhoto(path = "path5", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
+                DisplayPhoto(path = "path6", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
+                DisplayPhoto(path = "path7", displayUrl = "https://uc22e31aef6a36e181d57a6476bb.dl.dropboxusercontent.com/cd/0/get/Cj5qyoPud7yM0bkFLj_ahit0-XS8f3FD-57rCYLNCpd0yOiWdPRShRWW3jMsPY3ia5UU06upCTtbLOKJgFoJW2oMUnDAZlVw0z89b-WwFi0AKjXJYO9n_IeBlkrymrPFQL4lxcssPivwfmj7v12sFSpsFmNqIj3Lg4nSJL7MbQVTaA/file"),
+                DisplayPhoto(path = "path8", displayUrl = "https://ucd9a1924bb018833562b691ca8c.dl.dropboxusercontent.com/cd/0/get/Cj7owZ5K5-eloVvbt9Ohh9bcB4F4PUbmXxu6xoU0oFvES6M4DI5Fq_Ll63QoxkWiFTEqQLyJRVDJReguiPEelUwxA7BPHh866KDaGcLi7OFEt0MBBrhgeAGy3_DhPFkoS5COJ1BmBQQRBOWnXaTjejpP8rvxTcgqkVfhX4BdZYQ54A/file"),
+            )
             _state.update { it.copy(photos = photos) }
         }
 

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/HorizontalSwiper.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/HorizontalSwiper.kt
@@ -28,7 +28,6 @@ fun HorizontalSwiper(
     onSwipeRight: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    var offsetX by remember { mutableFloatStateOf(0f) }
     val swipeThreshold = 300f
     var offsetX by remember { mutableFloatStateOf(0f) }
     val animatedOffset by animateFloatAsState(
@@ -66,13 +65,13 @@ fun HorizontalSwiper(
             }
             .graphicsLayer {
                 // add an offset, but don't go more than the swipe threshold
-                rotationZ = offsetX.coerceIn(-swipeThreshold..swipeThreshold) / 15f
+                rotationZ = animatedOffset.coerceIn(-swipeThreshold..swipeThreshold) / 15f
             }
             .offset {
                 // add an offset, but don't go more than the swipe threshold
                 IntOffset(
-                    x = offsetX.coerceIn(-swipeThreshold..swipeThreshold).roundToInt() * 2,
-                    y = offsetX.absoluteValue.coerceAtMost(swipeThreshold).times(-0.5f).roundToInt(),
+                    x = animatedOffset.coerceIn(-swipeThreshold..swipeThreshold).roundToInt() * 2,
+                    y = animatedOffset.absoluteValue.coerceAtMost(swipeThreshold).times(-0.5f).roundToInt(),
                 )
             }
     ) {

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/HorizontalSwiper.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/HorizontalSwiper.kt
@@ -28,6 +28,7 @@ fun HorizontalSwiper(
     onSwipeRight: () -> Unit,
     content: @Composable () -> Unit,
 ) {
+    var offsetX by remember { mutableFloatStateOf(0f) }
     val swipeThreshold = 300f
     var offsetX by remember { mutableFloatStateOf(0f) }
     val animatedOffset by animateFloatAsState(
@@ -65,13 +66,13 @@ fun HorizontalSwiper(
             }
             .graphicsLayer {
                 // add an offset, but don't go more than the swipe threshold
-                rotationZ = animatedOffset.coerceIn(-swipeThreshold..swipeThreshold) / 15f
+                rotationZ = offsetX.coerceIn(-swipeThreshold..swipeThreshold) / 15f
             }
             .offset {
                 // add an offset, but don't go more than the swipe threshold
                 IntOffset(
-                    x = animatedOffset.coerceIn(-swipeThreshold..swipeThreshold).roundToInt() * 2,
-                    y = animatedOffset.absoluteValue.coerceAtMost(swipeThreshold).times(-0.5f).roundToInt(),
+                    x = offsetX.coerceIn(-swipeThreshold..swipeThreshold).roundToInt() * 2,
+                    y = offsetX.absoluteValue.coerceAtMost(swipeThreshold).times(-0.5f).roundToInt(),
                 )
             }
     ) {

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/OneWayVerticalSwiper.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/OneWayVerticalSwiper.kt
@@ -1,11 +1,5 @@
 package com.duchastel.simon.photocategorizer.ui.components
 
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.pager.PagerScope
-import androidx.compose.foundation.pager.PagerState
-import androidx.compose.foundation.pager.VerticalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -15,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -25,8 +18,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.PointerEvent
-import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntOffset
@@ -34,17 +25,12 @@ import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 
 @Composable
-fun <T> OneWayVerticalSwiper(
+fun OneWayVerticalSwiper(
     modifier: Modifier = Modifier,
-    items: List<T>,
-    onSwipe: (T) -> Unit,
-    content: @Composable (T) -> Unit,
+    onSwipe: (Int) -> Unit,
+    content: @Composable (Int) -> Unit,
 ) {
     var currentIndex by remember { mutableIntStateOf(0) }
-    val currentIndexSafe by remember(currentIndex) {
-        derivedStateOf { currentIndex.coerceAtMost(items.lastIndex) }
-    }
-    if (currentIndex > items.lastIndex) return // don't render with no elements left
 
     var containerHeight by remember { mutableIntStateOf(0) }
     val threshold by remember(containerHeight) { derivedStateOf { containerHeight / 2.5f } }
@@ -99,7 +85,7 @@ fun <T> OneWayVerticalSwiper(
                     onDragEnd = {
                         if (offsetY < -threshold) {
                             containerFlyingOffScreen = true
-                            onSwipe(items[currentIndexSafe])
+                            onSwipe(currentIndex)
                         } else {
                             // Reset position without changing indices
                             offsetY = 0f
@@ -125,7 +111,7 @@ fun <T> OneWayVerticalSwiper(
                     )
                 }
         ) {
-            content(items[currentIndexSafe])
+            content(currentIndex)
         }
     }
 }

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/OneWayVerticalSwiper.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/OneWayVerticalSwiper.kt
@@ -1,5 +1,11 @@
 package com.duchastel.simon.photocategorizer.ui.components
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.pager.PagerScope
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -9,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -18,6 +25,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntOffset

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/Shimmer.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/Shimmer.kt
@@ -14,9 +14,9 @@ import androidx.compose.ui.graphics.Color
 
 @Composable
 fun shimmerBrush(
-    width: Float = 2000f,
+    width: Float = 3000f,
     delayMillis: Int = 0,
-    durationMillis: Int = 1000,
+    durationMillis: Int = 1500,
 ): Brush {
     val colors = listOf(
         Color.LightGray.copy(alpha = 0.6f),
@@ -26,8 +26,8 @@ fun shimmerBrush(
 
     val transition = rememberInfiniteTransition(label = "Shimmer")
     val translateAnimation by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = width,
+        initialValue = -width,
+        targetValue = 2 * width,
         animationSpec = infiniteRepeatable(
             animation = tween(
                 durationMillis = durationMillis,
@@ -41,7 +41,7 @@ fun shimmerBrush(
 
     return Brush.linearGradient(
         colors = colors,
-        start = Offset(x = translateAnimation - width, y = 0.0f),
-        end = Offset(x = translateAnimation, y = 0.0f),
+        start = Offset(x = translateAnimation - width, y = 0f),
+        end = Offset(x = translateAnimation, y = 0f),
     )
 }

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/Shimmer.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/Shimmer.kt
@@ -14,10 +14,10 @@ import androidx.compose.ui.graphics.Color
 
 @Composable
 fun shimmerBrush(
+    width: Float = 2000f,
     delayMillis: Int = 0,
     durationMillis: Int = 1000,
 ): Brush {
-    val width = 1500f
     val colors = listOf(
         Color.LightGray.copy(alpha = 0.6f),
         Color.LightGray.copy(alpha = 0.2f),

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/Shimmer.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/Shimmer.kt
@@ -1,0 +1,47 @@
+package com.duchastel.simon.photocategorizer.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun shimmerBrush(
+    delayMillis: Int = 0,
+    durationMillis: Int = 1000,
+): Brush {
+    val width = 1500f
+    val colors = listOf(
+        Color.LightGray.copy(alpha = 0.6f),
+        Color.LightGray.copy(alpha = 0.2f),
+        Color.LightGray.copy(alpha = 0.6f),
+    )
+
+    val transition = rememberInfiniteTransition(label = "Shimmer")
+    val translateAnimation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = width,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = durationMillis,
+                easing = LinearEasing,
+                delayMillis = delayMillis
+            ),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "Shimmer"
+    )
+
+    return Brush.linearGradient(
+        colors = colors,
+        start = Offset(x = translateAnimation - width, y = 0.0f),
+        end = Offset(x = translateAnimation, y = 0.0f),
+    )
+}

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/SkeletonLoader.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/SkeletonLoader.kt
@@ -1,0 +1,63 @@
+package com.duchastel.simon.photocategorizer.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.random.Random
+
+@Composable
+fun SkeletonLoader(
+    modifier: Modifier = Modifier,
+    spacing: Dp = 12.dp,
+    barHeight: Dp = 16.dp
+) {
+    // Calculate number of bars based on available height
+    val density = LocalDensity.current
+    var containerHeight by remember { mutableIntStateOf(0) }
+    val numberOfBars by with(density) {
+        remember(containerHeight, spacing, barHeight) {
+            derivedStateOf {
+                ((containerHeight / (barHeight + spacing).toPx()).toInt()).coerceAtLeast(1)
+            }
+        }
+    }
+
+    // Random widths for bars between 60% and 95%
+    val randomWidths = remember(numberOfBars) {
+        List(numberOfBars) { Random.nextFloat() * 0.35f + 0.6f }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .onSizeChanged { containerHeight = it.height },
+        verticalArrangement = Arrangement.spacedBy(spacing)
+    ) {
+        repeat(numberOfBars) { index ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(randomWidths[index])
+                    .height(barHeight)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(shimmerBrush(delayMillis = index * 150))
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/SkeletonLoader.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/SkeletonLoader.kt
@@ -25,38 +25,107 @@ import kotlin.random.Random
 @Composable
 fun SkeletonLoader(
     modifier: Modifier = Modifier,
-    spacing: Dp = 12.dp,
-    barHeight: Dp = 16.dp
+    blockSpacing: Dp = 24.dp,
+    groupSpacing: Dp = 12.dp,
+    barHeight: Dp = 16.dp,
+    blockHeight: Dp = 120.dp,
+    bottomSpacing: Dp = 32.dp
 ) {
-    // Calculate number of bars based on available height
     val density = LocalDensity.current
     var containerHeight by remember { mutableIntStateOf(0) }
-    val numberOfBars by with(density) {
-        remember(containerHeight, spacing, barHeight) {
+
+    // Calculate number of block groups that can fit
+    val numberOfGroups by with(density) {
+        remember(containerHeight, blockSpacing, blockHeight, bottomSpacing) {
             derivedStateOf {
-                ((containerHeight / (barHeight + spacing).toPx()).toInt()).coerceAtLeast(1)
+                val totalGroupHeight = blockHeight + (barHeight * 3) + (groupSpacing * 3)
+                val availableHeight = containerHeight - bottomSpacing.toPx()
+                (availableHeight / totalGroupHeight.toPx()).toInt().coerceAtLeast(1)
             }
         }
-    }
-
-    // Random widths for bars between 60% and 95%
-    val randomWidths = remember(numberOfBars) {
-        List(numberOfBars) { Random.nextFloat() * 0.35f + 0.6f }
     }
 
     Column(
         modifier = modifier
             .fillMaxSize()
             .onSizeChanged { containerHeight = it.height },
-        verticalArrangement = Arrangement.spacedBy(spacing)
+        verticalArrangement = Arrangement.spacedBy(blockSpacing)
     ) {
-        repeat(numberOfBars) { index ->
+        repeat(numberOfGroups) {
+            SkeletonGroup(
+                modifier = Modifier.fillMaxWidth(),
+                blockHeight = blockHeight,
+                barHeight = barHeight,
+                groupSpacing = groupSpacing
+            )
+        }
+    }
+}
+
+@Composable
+private fun SkeletonGroup(
+    modifier: Modifier = Modifier,
+    blockHeight: Dp,
+    barHeight: Dp,
+    groupSpacing: Dp,
+    shimmerDelayMillis: Int = 0,
+) {
+    var containerWidth by remember { mutableIntStateOf(0) }
+    Column(
+        verticalArrangement = Arrangement.spacedBy(groupSpacing)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .onSizeChanged { containerWidth = it.width }
+                .height(blockHeight)
+                .clip(RoundedCornerShape(8.dp))
+                .background(
+                    shimmerBrush(
+                        delayMillis = shimmerDelayMillis,
+                        width = containerWidth.toFloat(),
+                    )
+                )
+        )
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(groupSpacing)
+        ) {
             Box(
                 modifier = Modifier
-                    .fillMaxWidth(randomWidths[index])
+                    .fillMaxWidth(0.95f)
                     .height(barHeight)
                     .clip(RoundedCornerShape(4.dp))
-                    .background(shimmerBrush(delayMillis = index * 150))
+                    .background(
+                        shimmerBrush(
+                            delayMillis = shimmerDelayMillis + 150, // offset 1st box by 150ms
+                            width = containerWidth.toFloat(),
+                        )
+                    )
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.8f)
+                    .height(barHeight)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(
+                        shimmerBrush(
+                            delayMillis = shimmerDelayMillis + 300, // offset 2nd box by 300ms
+                            width = containerWidth.toFloat(),
+                        )
+                    )
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.6f)
+                    .height(barHeight)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(
+                        shimmerBrush(
+                            delayMillis = shimmerDelayMillis + 450, // offset 2nd box by 450ms
+                            width = containerWidth.toFloat(),
+                        )
+                    )
             )
         }
     }

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/SkeletonLoader.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/SkeletonLoader.kt
@@ -20,12 +20,11 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlin.random.Random
 
 @Composable
 fun SkeletonLoader(
     modifier: Modifier = Modifier,
-    blockSpacing: Dp = 24.dp,
+    blockSpacing: Dp = 32.dp,
     groupSpacing: Dp = 12.dp,
     barHeight: Dp = 16.dp,
     blockHeight: Dp = 120.dp,
@@ -34,7 +33,6 @@ fun SkeletonLoader(
     val density = LocalDensity.current
     var containerHeight by remember { mutableIntStateOf(0) }
 
-    // Calculate number of block groups that can fit
     val numberOfGroups by with(density) {
         remember(containerHeight, blockSpacing, blockHeight, bottomSpacing) {
             derivedStateOf {
@@ -51,12 +49,13 @@ fun SkeletonLoader(
             .onSizeChanged { containerHeight = it.height },
         verticalArrangement = Arrangement.spacedBy(blockSpacing)
     ) {
-        repeat(numberOfGroups) {
+        repeat(numberOfGroups) { groupIndex ->
             SkeletonGroup(
                 modifier = Modifier.fillMaxWidth(),
                 blockHeight = blockHeight,
                 barHeight = barHeight,
-                groupSpacing = groupSpacing
+                groupSpacing = groupSpacing,
+                shimmerDelayMillis = groupIndex * 200 // Add delay between groups
             )
         }
     }
@@ -71,19 +70,20 @@ private fun SkeletonGroup(
     shimmerDelayMillis: Int = 0,
 ) {
     var containerWidth by remember { mutableIntStateOf(0) }
+
     Column(
+        modifier = modifier.onSizeChanged { containerWidth = it.width },
         verticalArrangement = Arrangement.spacedBy(groupSpacing)
     ) {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .onSizeChanged { containerWidth = it.width }
                 .height(blockHeight)
                 .clip(RoundedCornerShape(8.dp))
                 .background(
                     shimmerBrush(
                         delayMillis = shimmerDelayMillis,
-                        width = containerWidth.toFloat(),
+                        width = containerWidth.toFloat()
                     )
                 )
         )
@@ -91,42 +91,21 @@ private fun SkeletonGroup(
         Column(
             verticalArrangement = Arrangement.spacedBy(groupSpacing)
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth(0.95f)
-                    .height(barHeight)
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(
-                        shimmerBrush(
-                            delayMillis = shimmerDelayMillis + 150, // offset 1st box by 150ms
-                            width = containerWidth.toFloat(),
+            val widthPercentages = listOf(0.95f, 0.8f, 0.6f)
+            widthPercentages.forEachIndexed { index, width ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(width)
+                        .height(barHeight)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(
+                            shimmerBrush(
+                                delayMillis = shimmerDelayMillis + (index + 1) * 150,
+                                width = containerWidth.toFloat(),
+                            )
                         )
-                    )
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth(0.8f)
-                    .height(barHeight)
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(
-                        shimmerBrush(
-                            delayMillis = shimmerDelayMillis + 300, // offset 2nd box by 300ms
-                            width = containerWidth.toFloat(),
-                        )
-                    )
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth(0.6f)
-                    .height(barHeight)
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(
-                        shimmerBrush(
-                            delayMillis = shimmerDelayMillis + 450, // offset 2nd box by 450ms
-                            width = containerWidth.toFloat(),
-                        )
-                    )
-            )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/utils/Extensions.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/utils/Extensions.kt
@@ -1,0 +1,8 @@
+package com.duchastel.simon.photocategorizer.utils
+
+fun <T> T.applyIf(condition: Boolean, block: T.() -> Unit): T {
+    if (condition) {
+        block()
+    }
+    return this
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ material = "1.12.0"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
 moshi = "1.15.2"
-coil = "2.6.0"
+coil = "3.0.4"
 kotlinx-serialization = "1.6.3"
 
 [libraries]
@@ -49,7 +49,8 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
 [plugins]


### PR DESCRIPTION
When the image comes into the foreground, it should ideally already be loaded for a seamless user experience.
- preload the images (buffer of 5)
- pre-render the next image (buffer of 1) - it's a bit janky (pre-render and set alpha to 0) but it seems to work!
- add loading shimmer (will probably update later, but good enough for now)
- Load max file paths at once from dropbox (must load all because they give it to you oldest-to-latest, not latest-to-oldest)
- small changes to build config
- fixes to compose view for image swiping


https://github.com/user-attachments/assets/19201623-9081-42bf-924f-ba05b1ca1565

