### PR TITLE
Save swiper state as rememberSaveable

### DIFF
--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/screens/photoswiper/PhotoSwiperScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/OneWayVerticalSwiper.kt
+++ b/app/src/main/java/com/duchastel/simon/photocategorizer/ui/components/OneWayVerticalSwiper.kt
@@ -16,6 +16,9 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -137,14 +140,17 @@ interface VerticalSwiperState {
 }
 
 @Composable
-fun rememberVerticalSwiperState(pageCount: () -> Int): VerticalSwiperState = remember {
-    DefaultVerticalSwiperState(pageCount = pageCount)
+fun rememberVerticalSwiperState(pageCount: () -> Int): VerticalSwiperState {
+    return rememberSaveable(saver = DefaultVerticalSwiperState.Saver) {
+        DefaultVerticalSwiperState(pageCount = pageCount)
+    }
 }
 
 private class DefaultVerticalSwiperState(
+    currentPage: Int = 0,
     pageCount: () -> Int
 ): VerticalSwiperState {
-    override var currentPage by mutableIntStateOf(0)
+    override var currentPage by mutableIntStateOf(currentPage)
         private set
 
     var pageCountState = mutableStateOf(pageCount)
@@ -153,5 +159,22 @@ private class DefaultVerticalSwiperState(
 
     override fun swipeToNextPage() {
         currentPage++
+    }
+
+    companion object {
+        val Saver: Saver<DefaultVerticalSwiperState, *> = listSaver(
+            save = {
+                listOf(
+                    it.currentPage,
+                    it.pageCount,
+                )
+            },
+            restore = {
+                DefaultVerticalSwiperState(
+                    currentPage = it[0],
+                    pageCount = { it[1] }
+                )
+            }
+        )
     }
 }


### PR DESCRIPTION
This adds the state in rememberSavable, which lets it persist between compositions because it's saved in a bundle by the Android system. This also applies to screen rotation.

Before, when navigating to the swiper screen and back the viewmodel is re-used (good!) but the index stored in the swiper composable is reset to 0 because view is recomposed. The impact of this is that processed photos are shown, which is invalid and a bad user experience.

Inspired by [PagerState](https://developer.android.com/reference/kotlin/androidx/compose/foundation/pager/PagerState) implementation