### PR TITLE
Replace MockK with Mockito in test suite

### DIFF
--- a/modules/ui/screens/settings/build.gradle.kts
+++ b/modules/ui/screens/settings/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.junit)
-    testImplementation("io.mockk:mockk:1.13.8")
+    testImplementation("org.mockito:mockito-core:5.8.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 }


### PR DESCRIPTION
## Summary
- Completely removed MockK dependency from the codebase and replaced it with Mockito
- Updated build.gradle.kts to use Mockito dependencies instead of MockK
- Migrated all test code from MockK syntax to Mockito syntax
- Updated mocking annotations, setup methods, stubbing, and verification calls

## Changes Made
- **Build Dependencies**: Replaced `io.mockk:mockk:1.13.8` with `org.mockito:mockito-core:5.8.0` and `org.mockito.kotlin:mockito-kotlin:5.2.1`
- **Annotations**: Changed `@MockK` to `@Mock`
- **Setup**: Replaced `MockKAnnotations.init()` with `MockitoAnnotations.openMocks()`
- **Stubbing**: Changed `every { ... } returns ...` to `whenever(...).thenReturn(...)`
- **Verification**: Updated `verify { ... }` to `verify(...).method()`
- **Exception Throwing**: Changed `throws` syntax to `thenThrow()`

## Files Modified
- `modules/ui/screens/settings/build.gradle.kts`
- `modules/ui/screens/settings/src/test/java/com/duchastel/simon/photocategorizer/screens/settings/SettingsViewModelTest.kt`

## Test Plan
- [x] Verified no MockK references remain in codebase
- [x] All MockK imports and usage replaced with Mockito equivalents
- [x] Build dependencies updated to use Mockito
- [x] Test syntax migrated to Mockito patterns

🤖 Generated with [Claude Code](https://claude.ai/code)