### PR TITLE
feat: create generic ValidatedTextField component

### DIFF
--- a/modules/ui/README.md
+++ b/modules/ui/README.md
@@ -22,6 +22,7 @@ Reusable UI components used across multiple screens:
 - **`HorizontalSwiper`** - Swipeable photo viewer component
 - **`OneWayVerticalSwiper`** - Vertical swipe component  
 - **`TextInputModal`** - Generic modal dialog with text input field and customizable text
+- **`ValidatedTextField`** - Text input field with validation and error handling capabilities
 - **`Shimmer`** - Loading shimmer effect
 - **`SkeletonLoader`** - Skeleton loading animations
 - **`SwipeDirection`** - Swipe direction enumeration

--- a/modules/ui/components/README.md
+++ b/modules/ui/components/README.md
@@ -6,6 +6,7 @@ Reusable UI components used throughout the app.
 - `HorizontalSwiper` - Swipeable photo viewer component
 - `OneWayVerticalSwiper` - Vertical swipe component
 - `TextInputModal` - Generic modal dialog with text input field and customizable text
+- `ValidatedTextField` - Text input field with validation and error handling capabilities
 - `Shimmer` - Loading shimmer effect
 - `SkeletonLoader` - Skeleton loading animations
 - `SwipeDirection` - Swipe direction enumeration

--- a/modules/ui/components/src/main/java/com/duchastel/simon/photocategorizer/ui/components/ValidatedTextField.kt
+++ b/modules/ui/components/src/main/java/com/duchastel/simon/photocategorizer/ui/components/ValidatedTextField.kt
@@ -18,7 +18,6 @@ fun ValidatedTextField(
     supportingText: String? = null,
     placeholder: String? = null,
     errorMessage: String? = null,
-    isError: Boolean = errorMessage != null,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
@@ -28,12 +27,12 @@ fun ValidatedTextField(
             label = { Text(label) },
             placeholder = placeholder?.let { { Text(it) } },
             supportingText = supportingText?.let { { Text(it) } },
-            isError = isError,
+            isError = errorMessage != null,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 8.dp)
         )
-        
+
         errorMessage?.let { error ->
             Text(
                 text = error,

--- a/modules/ui/components/src/main/java/com/duchastel/simon/photocategorizer/ui/components/ValidatedTextField.kt
+++ b/modules/ui/components/src/main/java/com/duchastel/simon/photocategorizer/ui/components/ValidatedTextField.kt
@@ -1,0 +1,46 @@
+package com.duchastel.simon.photocategorizer.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ValidatedTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    supportingText: String? = null,
+    placeholder: String? = null,
+    errorMessage: String? = null,
+    isError: Boolean = errorMessage != null,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(label) },
+            placeholder = placeholder?.let { { Text(it) } },
+            supportingText = supportingText?.let { { Text(it) } },
+            isError = isError,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp)
+        )
+        
+        errorMessage?.let { error ->
+            Text(
+                text = error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+    }
+}

--- a/modules/ui/screens/settings/src/main/java/com/duchastel/simon/photocategorizer/screens/settings/SettingsScreen.kt
+++ b/modules/ui/screens/settings/src/main/java/com/duchastel/simon/photocategorizer/screens/settings/SettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.Text
+import com.duchastel.simon.photocategorizer.ui.components.ValidatedTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -168,72 +169,31 @@ private fun SettingsContent(
                     )
 
                     // Camera Roll Path
-                    OutlinedTextField(
+                    ValidatedTextField(
                         value = state.userSettings.cameraRollPath,
                         onValueChange = onCameraRollPathChanged,
-                        label = { Text("Camera Roll Location") },
-                        supportingText = {
-                            Text("Source folder containing photos to categorize")
-                        },
-                        isError = state.cameraRollPathError != null,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 8.dp)
+                        label = "Camera Roll Location",
+                        supportingText = "Source folder containing photos to categorize",
+                        errorMessage = state.cameraRollPathError
                     )
-                    
-                    state.cameraRollPathError?.let { error ->
-                        Text(
-                            text = error,
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.padding(bottom = 8.dp)
-                        )
-                    }
 
                     // Destination Folder Path
-                    OutlinedTextField(
+                    ValidatedTextField(
                         value = state.userSettings.destinationFolderPath,
                         onValueChange = onDestinationFolderPathChanged,
-                        label = { Text("Destination Folder") },
-                        supportingText = {
-                            Text("Target folder for right swipe categorization")
-                        },
-                        isError = state.destinationFolderPathError != null,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 8.dp)
+                        label = "Destination Folder",
+                        supportingText = "Target folder for right swipe categorization",
+                        errorMessage = state.destinationFolderPathError
                     )
-                    
-                    state.destinationFolderPathError?.let { error ->
-                        Text(
-                            text = error,
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.padding(bottom = 8.dp)
-                        )
-                    }
 
                     // Archive Folder Path
-                    OutlinedTextField(
+                    ValidatedTextField(
                         value = state.userSettings.archiveFolderPath,
                         onValueChange = onArchiveFolderPathChanged,
-                        label = { Text("Archive Folder") },
-                        supportingText = {
-                            Text("Target folder for up swipe archiving")
-                        },
-                        isError = state.archiveFolderPathError != null,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 8.dp)
+                        label = "Archive Folder",
+                        supportingText = "Target folder for up swipe archiving",
+                        errorMessage = state.archiveFolderPathError
                     )
-                    
-                    state.archiveFolderPathError?.let { error ->
-                        Text(
-                            text = error,
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
                 }
             }
 


### PR DESCRIPTION
Created a generic ValidatedTextField component that abstracts the common pattern from the settings screen.  Component encapsulates both the OutlinedTextField and error message display with proper Material 3 theming

Closes #38 