### PR TITLE
feat: create generic AutoDismissSnackbar component

### DIFF
--- a/modules/ui/components/README.md
+++ b/modules/ui/components/README.md
@@ -3,6 +3,7 @@
 Reusable UI components used throughout the app.
 
 ## Components
+- `AutoDismissSnackbar` - Auto-dismissing snackbar component with configurable duration
 - `HorizontalSwiper` - Swipeable photo viewer component
 - `OneWayVerticalSwiper` - Vertical swipe component
 - `TextInputModal` - Generic modal dialog with text input field and customizable text

--- a/modules/ui/components/src/main/java/com/duchastel/simon/photocategorizer/ui/components/AutoDismissSnackbar.kt
+++ b/modules/ui/components/src/main/java/com/duchastel/simon/photocategorizer/ui/components/AutoDismissSnackbar.kt
@@ -1,0 +1,42 @@
+package com.duchastel.simon.photocategorizer.ui.components
+
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.delay
+
+/**
+ * A generic Snackbar component that automatically dismisses after a specified duration.
+ * 
+ * This component encapsulates both the timing logic (LaunchedEffect) and the Snackbar display,
+ * making it reusable across the application for showing temporary messages.
+ *
+ * @param message The text message to display in the snackbar
+ * @param isVisible Whether the snackbar should be visible
+ * @param onDismiss Callback invoked when the snackbar should be dismissed
+ * @param duration Duration in milliseconds before auto-dismissal (default: 3000ms)
+ * @param modifier Modifier to be applied to the snackbar
+ */
+@Composable
+fun AutoDismissSnackbar(
+    message: String,
+    isVisible: Boolean,
+    onDismiss: () -> Unit,
+    duration: Long = 3000L,
+    modifier: Modifier = Modifier
+) {
+    if (isVisible) {
+        LaunchedEffect(isVisible) {
+            delay(duration)
+            onDismiss()
+        }
+        
+        Snackbar(
+            modifier = modifier
+        ) {
+            Text(message)
+        }
+    }
+}

--- a/modules/ui/screens/settings/src/main/java/com/duchastel/simon/photocategorizer/screens/settings/SettingsScreen.kt
+++ b/modules/ui/screens/settings/src/main/java/com/duchastel/simon/photocategorizer/screens/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.duchastel.simon.photocategorizer.ui.components.AutoDismissSnackbar
 import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -277,30 +278,18 @@ private fun SettingsContent(
         }
 
         // Success/Error Messages
-        if (state.showSuccessMessage) {
-            LaunchedEffect(state.showSuccessMessage) {
-                delay(3000) // Show snackbar for 3 seconds
-                onSuccessMessageShown()
-            }
-            
-            Snackbar(
-                modifier = Modifier.padding(top = 16.dp)
-            ) {
-                Text("Settings saved successfully!")
-            }
-        }
+        AutoDismissSnackbar(
+            message = "Settings saved successfully!",
+            isVisible = state.showSuccessMessage,
+            onDismiss = onSuccessMessageShown,
+            modifier = Modifier.padding(top = 16.dp)
+        )
 
-        if (state.showErrorMessage) {
-            LaunchedEffect(state.showErrorMessage) {
-                delay(3000) // Show snackbar for 3 seconds
-                onErrorMessageShown()
-            }
-            
-            Snackbar(
-                modifier = Modifier.padding(top = 16.dp)
-            ) {
-                Text("Error saving settings. Please try again.")
-            }
-        }
+        AutoDismissSnackbar(
+            message = "Error saving settings. Please try again.",
+            isVisible = state.showErrorMessage,
+            onDismiss = onErrorMessageShown,
+            modifier = Modifier.padding(top = 16.dp)
+        )
     }
 }


### PR DESCRIPTION
 Extracted auto-dismiss snackbar pattern from SettingsScreen into a reusable AutoDismissSnackbar component. Component encapsulates both the LaunchedEffect timing logic and Snackbar display

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)